### PR TITLE
feat: add export report and recent repos sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-vite
 .output
 .env
 .vercel
+.env.local

--- a/src/components/ExportReport.island.tsx
+++ b/src/components/ExportReport.island.tsx
@@ -1,0 +1,120 @@
+import { useState } from "hono/jsx";
+import { ghlocApi } from "~/lib/ghloc/api";
+import { SpinnerIcon } from "~/components/icons/SpinnerIcon";
+
+interface ExportReportProps {
+	owner: string;
+	repo: string;
+	data?: any;
+	defaultBranch?: string | null;
+}
+
+export default function ExportReport({ owner, repo, data, defaultBranch }: ExportReportProps) {
+	const [loading, setLoading] = useState(false);
+
+	const handleExport = async () => {
+		setLoading(true);
+		try {
+			// Fetch LOC data
+			let locs: any = null;
+			try {
+				const branchParam = defaultBranch || undefined;
+				locs = await ghlocApi.getLocs({ owner, repo, branch: branchParam });
+			} catch (e) {
+				console.warn("Failed to fetch LOC data", e);
+			}
+
+			const lines: string[] = [];
+
+			// Helper: Convert KB to MB
+			const formatSize = (sizeKB: number): string => {
+				if (!sizeKB) return "N/A";
+				const sizeMB = sizeKB / 1000;
+				return `${sizeMB.toFixed(2)} MB`;
+			};
+
+			// Header
+			lines.push(`# ${owner}/${repo}`);
+			lines.push("");
+			lines.push(`Repository: https://github.com/${owner}/${repo}`);
+
+			if (data?.description) {
+				lines.push("");
+				lines.push(data.description);
+				lines.push("");
+			}
+
+			if (data?.topics && data.topics.length) {
+				lines.push(`Topics: ${data.topics.join(", ")}`);
+				lines.push("");
+			}
+
+			// Statistics
+			lines.push("## Statistics");
+			lines.push("");
+			lines.push(`- **Stars:** ${data?.stargazers_count ?? "N/A"}`);
+			lines.push(`- **Forks:** ${data?.forks ?? "N/A"}`);
+			lines.push(`- **Watchers:** ${data?.subscribers_count ?? "N/A"}`);
+			lines.push(`- **Open Issues:** ${data?.open_issues_count ?? "N/A"}`);
+			lines.push(`- **Repository Size:** ${data?.size ? formatSize(data.size) : "N/A"}`);
+			lines.push(`- **Default Branch:** ${data?.default_branch ?? "N/A"}`);
+
+			if (data?.license) {
+				lines.push(`- **License:** ${data.license.name}`);
+			}
+			if (data?.homepage) {
+				lines.push(`- **Homepage:** ${data.homepage}`);
+			}
+
+			// Lines of Code
+			lines.push("");
+			lines.push("## Lines of Code");
+			lines.push("");
+			lines.push(`- **Total:** ${locs?.loc ?? "N/A"}`);
+
+			if (locs?.locByLangs && Object.keys(locs.locByLangs).length) {
+				lines.push("");
+				lines.push("### Breakdown by Language");
+				for (const [lang, count] of Object.entries(locs.locByLangs)) {
+					lines.push(`- **${lang}:** ${count}`);
+				}
+			}
+
+			// Footer
+			lines.push("");
+			lines.push(`---
+*Report generated on ${new Date().toISOString()} by [ghloc-web](https://github.com/pajecawav/ghloc-web)*`);
+
+			// Download
+			const content = lines.join("\n");
+			const blob = new Blob([content], { type: "text/markdown" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${owner}-${repo}-report.md`;
+			document.body.appendChild(a);
+			a.click();
+			a.remove();
+			URL.revokeObjectURL(url);
+
+			alert("Export completed");
+		} catch (err) {
+			console.error(err);
+			alert("Export failed");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<div>
+			<button
+				class="border-border hover:border-border-focus flex items-center gap-2 rounded-md border px-3 py-1 text-sm"
+				onClick={handleExport}
+				disabled={loading}
+			>
+				{loading ? <SpinnerIcon class="h-4 w-4 animate-spin" /> : "Export MD"}
+			</button>
+		</div>
+	);
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,15 +2,22 @@ import { PropsWithChildren } from "hono/jsx";
 import { Header } from "./Header";
 import { Island } from "~/lib/island";
 import Toaster from "./Toaster.island";
+import RecentRepos from "~/components/RecentRepos.island";
 
 export const Layout = ({ children }: PropsWithChildren) => {
 	return (
-		<main class="mx-auto flex min-h-full max-w-3xl flex-col p-2">
-			<Header />
+		<>
+			<div class="fixed top-24 right-4 z-50 hidden lg:block">
+				<Island Component={RecentRepos} props={{}} />
+			</div>
 
-			{children}
+			<main class="mx-auto flex min-h-full max-w-3xl flex-col p-2">
+				<Header />
 
-			<Island Component={Toaster} props={{}} />
-		</main>
+				{children}
+
+				<Island Component={Toaster} props={{}} />
+			</main>
+		</>
 	);
 };

--- a/src/components/RecentRepos.island.tsx
+++ b/src/components/RecentRepos.island.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "hono/jsx";
+
+const STORAGE_KEY = "recentRepos";
+const MAX_ITEMS = 8;
+
+const readList = () => {
+	if (typeof window === "undefined") return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		const list = raw ? JSON.parse(raw) : [];
+		return list.slice(0, MAX_ITEMS);
+	} catch {
+		return [];
+	}
+};
+
+export default function RecentRepos() {
+	const [list, setList] = useState(() => readList());
+
+	useEffect(() => {
+		const onUpdate = () => setList(readList());
+
+		window.addEventListener("recent-repos-updated", onUpdate);
+		window.addEventListener("storage", onUpdate);
+
+		return () => {
+			window.removeEventListener("recent-repos-updated", onUpdate);
+			window.removeEventListener("storage", onUpdate);
+		};
+	}, []);
+
+	if (!list || list.length === 0) return null;
+
+	const clearAll = () => {
+		localStorage.removeItem(STORAGE_KEY);
+		setList([]);
+		window.dispatchEvent(new Event("recent-repos-updated"));
+	};
+
+	return (
+		<aside class="border-border bg-surface w-64 rounded-md border p-2 text-sm">
+			<div class="mb-2 flex items-center justify-between">
+				<div class="font-medium">Recent Repos</div>
+				<button
+					class="text-muted text-xs hover:underline"
+					onClick={clearAll}
+					title="Clear recent repos"
+				>
+					Clear
+				</button>
+			</div>
+
+			<ul class="flex flex-col gap-1">
+				{list.map((item: any) => (
+					<li key={item.id} class="hover:bg-muted rounded">
+						<a
+							class="block px-2 py-1"
+							href={`/${item.owner}/${item.repo}${item.defaultBranch ? `?branch=${encodeURIComponent(item.defaultBranch)}` : ""}`}
+						>
+							<div class="truncate">
+								{item.owner}/{item.repo}
+							</div>
+							<div class="text-muted text-xs">
+								{new Date(item.ts).toLocaleString()}
+							</div>
+						</a>
+					</li>
+				))}
+			</ul>
+		</aside>
+	);
+}

--- a/src/components/TrackVisit.island.tsx
+++ b/src/components/TrackVisit.island.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "hono/jsx";
+
+interface TrackVisitProps {
+	owner: string;
+	repo: string;
+	defaultBranch?: string | null;
+}
+
+const MAX_ITEMS = 8;
+
+const pushRecentRepo = (owner: string, repo: string, defaultBranch?: string | null) => {
+	try {
+		const key = "recentRepos";
+		const raw = localStorage.getItem(key);
+		let list: Array<any> = raw ? JSON.parse(raw) : [];
+
+		const id = `${owner}/${repo}`;
+
+		list = list.filter(item => item.id !== id);
+
+		list.unshift({ id, owner, repo, defaultBranch: defaultBranch ?? null, ts: Date.now() });
+
+		if (list.length > MAX_ITEMS) list = list.slice(0, MAX_ITEMS);
+
+		localStorage.setItem(key, JSON.stringify(list));
+
+		// notify other islands in the same tab
+		try {
+			window.dispatchEvent(new Event("recent-repos-updated"));
+		} catch {
+			// ignore
+		}
+	} catch {
+		// ignore
+	}
+};
+
+export default function TrackVisit({ owner, repo, defaultBranch }: TrackVisitProps) {
+	useEffect(() => {
+		if (!owner || !repo) return;
+
+		pushRecentRepo(owner, repo, defaultBranch);
+	}, [owner, repo, defaultBranch]);
+
+	return null;
+}

--- a/src/lib/github/api.ts
+++ b/src/lib/github/api.ts
@@ -113,17 +113,32 @@ export const ghApi = {
 				return result && Array.isArray(result) ? result : null;
 			};
 
-			const request = async () => {
-				const result = await baseFetcher.raw<GHApiGetCommitActivityResponse>(
+			const MAX_RETRIES = 5;
+			const BASE_DELAY = 2000;
+
+			const request = async (attempt = 1) => {
+				const result = await fetcher.raw<GHApiGetCommitActivityResponse>(
 					`https://api.github.com/repos/${owner}/${repo}/stats/commit_activity`,
 				);
 
-				if (isClient && result.status === 202) {
-					await sleep(10_000);
-					return request();
+				if (result.status !== 202 || !isClient) {
+					return clean(result._data);
 				}
 
-				return clean(result._data);
+				if (attempt >= MAX_RETRIES) {
+					console.warn(
+						`Commit activity timeout for ${owner}/${repo} after ${MAX_RETRIES} attempts`,
+					);
+					return null;
+				}
+
+				// 2s, 4s, 8s, 16s, 32s
+				const delay = BASE_DELAY * Math.pow(2, attempt - 1);
+				console.log(
+					`Commit activity still processing, retry ${attempt}/${MAX_RETRIES} in ${delay}ms`,
+				);
+				await sleep(delay);
+				return request(attempt + 1);
 			};
 
 			return request();

--- a/src/pages/repo/components/InfoSection.tsx
+++ b/src/pages/repo/components/InfoSection.tsx
@@ -4,6 +4,9 @@ import { ExternalLinkIcon } from "~/components/icons/ExternalLinkIcon";
 import { GitHubIcon } from "~/components/icons/GitHubIcon";
 import { Link } from "~/components/Link";
 import { RepoStats } from "~/components/RepoStats";
+import { Island } from "~/lib/island";
+import ExportReport from "~/components/ExportReport.island";
+import TrackVisit from "~/components/TrackVisit.island";
 import { formatBytes } from "~/lib/format";
 import { removeProtocol } from "~/lib/utils";
 import { CommonSectionProps } from "../types";
@@ -39,11 +42,24 @@ export const InfoSection = async ({ owner, repo, data }: InfoSectionProps) => {
 					<Badge title="Repo size">{formatBytes(data.size * 1024, 0)}</Badge>
 				</div>
 
-				<RepoStats
-					watchers={data.subscribers_count}
-					stars={data.stargazers_count}
-					forks={data.forks}
-				/>
+				<div class="flex items-center gap-2">
+					<RepoStats
+						watchers={data.subscribers_count}
+						stars={data.stargazers_count}
+						forks={data.forks}
+					/>
+
+					<Island
+						Component={ExportReport}
+						props={{ owner, repo, data, defaultBranch: data.default_branch }}
+					/>
+
+					{/* Track visit (client-side only) */}
+					<Island
+						Component={TrackVisit}
+						props={{ owner, repo, defaultBranch: data.default_branch }}
+					/>
+				</div>
 			</div>
 
 			{data.topics && data.topics.length !== 0 && (


### PR DESCRIPTION
## Summary

This PR adds three major features to improve user experience:
1. Export repository statistics as Markdown report (feat)
2. Recent repositories sidebar for quick navigation (feat)
3. Improved commit activity retry logic (fix)

Considering that users might want to download the statistics they've gathered, I added an export to Markdown feature. Also, since this is a browser extension, I believe search/visit history is also a necessary feature.

While using this tool, I noticed that commit information often fails to load properly. Although I understand this is due to how the GitHub API processes these requests, there were also some minor issues in the current code logic: after receiving a 202 status, the polling mechanism didn't include the token, so it failed after just two attempts. My fix adds the token during polling, implements a maximum retry limit, and uses exponential backoff. This should help with fetching commit information — though perhaps the retry strategy could be further adjusted.