### PR TITLE
feat: add ctrl+k keyboard shortcut for search focus

### DIFF
--- a/src/pages/index/components/IndexPageContent.island.lazy.tsx
+++ b/src/pages/index/components/IndexPageContent.island.lazy.tsx
@@ -28,6 +28,19 @@ export default function IndexPageContent() {
 
 	useEffect(() => {
 		inputRef.current?.focus();
+
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				inputRef.current?.focus();
+			}
+		};
+
+		document.addEventListener("keydown", onKeyDown);
+
+		return () => {
+			document.removeEventListener("keydown", onKeyDown);
+		};
 	}, []);
 
 	useLayoutEffect(() => {


### PR DESCRIPTION
hey, implemented the ctrl+k shortcut as discussed in #144. it uses a global keydown listener on the index page and handles the metaKey/ctrlKey check for mac/windows. also added cleanup logic for the listener. passes linting and tsc. let me know what you think!