### PR TITLE
Detect YAML issue forms in repo health

### DIFF
--- a/src/lib/github/api.ts
+++ b/src/lib/github/api.ts
@@ -56,6 +56,42 @@ export type GHApiSearchReposResponse = Endpoints["GET /search/repositories"]["re
 
 export type GHApiGetReposResponse = Endpoints["GET /users/{username}/repos"]["response"]["data"];
 
+type GHApiRepoHealthFile = NonNullable<
+	NonNullable<GHApiGetRepoHealthResponse["files"]>["issue_template"]
+>;
+
+type GHApiContentItem = {
+	name: string;
+	type: string;
+	url: string;
+	html_url: string | null;
+};
+
+const issueTemplateFileRegex = /\.(?:md|ya?ml)$/i;
+const issueTemplateConfigRegex = /^config\.ya?ml$/i;
+
+const getContents = async (owner: string, repo: string, path: string) => {
+	try {
+		return await fetcher<GHApiContentItem | GHApiContentItem[]>(
+			`https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+		);
+	} catch (error) {
+		if (error instanceof FetchError && error.statusCode === 404) {
+			return null;
+		}
+
+		throw error;
+	}
+};
+
+const isIssueTemplateFile = (item: GHApiContentItem) => {
+	return (
+		item.type === "file" &&
+		issueTemplateFileRegex.test(item.name) &&
+		!issueTemplateConfigRegex.test(item.name)
+	);
+};
+
 export const ghApi = {
 	getRepo: cachedApiFunction("ghApi.getRepo", (owner: string, repo: string) => {
 		return fetcher<GHApiGetRepoResponse>(`https://api.github.com/repos/${owner}/${repo}`);
@@ -66,6 +102,32 @@ export const ghApi = {
 			`https://api.github.com/repos/${owner}/${repo}/community/profile`,
 		);
 	}),
+
+	getIssueTemplate: cachedApiFunction(
+		"ghApi.getIssueTemplate",
+		async (owner: string, repo: string): Promise<GHApiRepoHealthFile | null> => {
+			const contents = await getContents(owner, repo, ".github/ISSUE_TEMPLATE");
+
+			if (!Array.isArray(contents)) {
+				return null;
+			}
+
+			const template = contents.find(isIssueTemplateFile);
+
+			if (!template) {
+				return null;
+			}
+
+			if (!template.html_url) {
+				return null;
+			}
+
+			return {
+				url: template.url,
+				html_url: template.html_url,
+			};
+		},
+	),
 
 	getFile: cachedApiFunction(
 		"ghApi.getFile",

--- a/src/pages/repo/components/HealthSection.tsx
+++ b/src/pages/repo/components/HealthSection.tsx
@@ -74,9 +74,13 @@ export const HealthSection = async ({ owner, repo, data }: HealthSectionProps) =
 		readme,
 		code_of_conduct: coc,
 		contributing,
-		issue_template: issue,
 		pull_request_template: pr,
 	} = health?.files ?? {};
+	let issue = health?.files?.issue_template;
+
+	if (!issue) {
+		issue = await timing.timeAsync("issue_template", () => ghApi.getIssueTemplate(owner, repo));
+	}
 
 	return (
 		<Section title={`${title} (${health.health_percentage.toFixed(0)}%)`}>


### PR DESCRIPTION
## Summary

Fixes a false “No issue template” status for repositories that use GitHub YAML issue forms.

`ghloc-web` currently relies on GitHub’s community profile API field `files.issue_template`. For [`mehmetdemircs/RepoSpend`](https://github.com/mehmetdemircs/RepoSpend), GitHub reports `health_percentage: 100`, but returns `files.issue_template: null` even though the repository has valid issue forms in `.github/ISSUE_TEMPLATE`.

This adds a fallback check against the repository contents API when `files.issue_template` is missing. The fallback detects `.md`, `.yml`, and `.yaml` issue template files under `.github/ISSUE_TEMPLATE`, while ignoring `config.yml`.

## Example

Repository: [`mehmetdemircs/RepoSpend`](https://github.com/mehmetdemircs/RepoSpend)

Issue forms:

- [`.github/ISSUE_TEMPLATE/bug_report.yml`](https://github.com/mehmetdemircs/RepoSpend/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml)
- [`.github/ISSUE_TEMPLATE/feature_request.yml`](https://github.com/mehmetdemircs/RepoSpend/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml)

## Before

[`mehmetdemircs/RepoSpend`](https://github.com/mehmetdemircs/RepoSpend) was shown as missing an issue template.

<img width="827" height="376" alt="image" src="https://github.com/user-attachments/assets/8a41a1b6-52e6-4bfd-b037-ea0b3146ee0d" />


## After

[`mehmetdemircs/RepoSpend`](https://github.com/mehmetdemircs/RepoSpend) is correctly shown as having an issue template.

<img width="802" height="379" alt="image" src="https://github.com/user-attachments/assets/a9292ed8-4b97-4814-b039-164a19af8385" />


## Verification

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Verified locally with `mehmetdemircs/RepoSpend?branch=main`