### PR TITLE
Added category exclusion filters for LOC calculation (UI and Badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ this README has the following URL and only counts files with `.ts` or `.tsx` ext
 https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/pajecawav/ghloc-web/badge?filter=.ts$,.tsx$
 ```
 
+You can exclude specific types of files from the calculation by using the `activeFilters` search param with a comma-separated list of categories (`jsonConfigs`, `lockfiles`, `buildScripts`, `environment`, `editorGit`, `cachesAndBinaries`). For example, to exclude config and lock files:
+
+```
+https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/OWNER/REPO/badge?activeFilters=jsonConfigs,lockfiles
+```
+
 To humanize LOC count you can add `format=human` to search params. So to a produce badge like [![lines
 count](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/pajecawav/ghloc-web/badge?format=human)](https://ghloc.vercel.app/pajecawav/ghloc-web)
 you can use following URL:

--- a/src/lib/ghloc/api.ts
+++ b/src/lib/ghloc/api.ts
@@ -16,7 +16,7 @@ export interface GhlocApiGetLocsParams {
 	repo: string;
 	branch?: string;
 	filter?: string;
-	ignoreConfigs?: boolean;
+	activeFilters?: string[];
 }
 
 export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetLocsParams) => {
@@ -35,53 +35,96 @@ export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetL
 	return url;
 };
 
-const IGNORED_PATTERNS = [
-	/^package\.json$/i,
-	/^tsconfig.*\.json$/i,
-	/^jsconfig.*\.json$/i,
-	/^composer\.json$/i,
-	/^angular\.json$/i,
-	/^nx\.json$/i,
-	/^lerna\.json$/i,
-	/lock$/i,
-	/pnpm-lock\.yaml$/i,
-	/gradle$/i,
-	/^gradlew$/i,
-	/^gradlew\.bat$/i,
-	/\.tsbuildinfo$/i,
-	/\.properties$/i,
-	/\.pro$/i,
-	/^makefile$/i,
-	/^pom\.xml$/i,
-	/^build\.xml$/i,
-	/^cargo\.toml$/i,
-	/vite\.config\./i,
-	/webpack\.config\./i,
-	/rollup\.config\./i,
-	/jest\.config\./i,
-	/babel\.config\./i,
-	/tailwind\.config\./i,
-	/postcss\.config\./i,
-	/^go\.mod$/i,
-	/^go\.sum$/i,
-	/^gemfile$/i,
-	/^\.gitignore$/i,
-	/^\.gitattributes$/i,
-	/^\.editorconfig$/i,
-	/^\.env/i,
-	/^dockerfile$/i,
-	/^docker-compose\./i,
-	/^requirements\.txt$/i,
-	/^pyproject\.toml$/i,
-	/^setup\.py$/i,
-	/^\.eslintrc/i,
-	/^\.prettierrc/i,
-	/^jenkinsfile$/i,
-	/\.(png|jpe?g|gif|svg|webp|ico|zip|tar|gz|rar|7z)$/i,
+export const FILTER_CATEGORIES = [
+	{
+		id: "jsonConfigs",
+		label: "JSON Configs",
+		patterns: [
+			/^package\.json$/i,
+			/^tsconfig.*\.json$/i,
+			/^jsconfig.*\.json$/i,
+			/^composer\.json$/i,
+			/^angular\.json$/i,
+			/^nx\.json$/i,
+			/^lerna\.json$/i,
+		],
+	},
+	{
+		id: "lockfiles",
+		label: "Lockfiles",
+		patterns: [
+			/lock$/i,
+			/pnpm-lock\.yaml$/i,
+			/^go\.sum$/i,
+		],
+	},
+	{
+		id: "buildScripts",
+		label: "Build Scripts",
+		patterns: [
+			/gradle$/i,
+			/^gradlew$/i,
+			/^gradlew\.bat$/i,
+			/^makefile$/i,
+			/^pom\.xml$/i,
+			/^build\.xml$/i,
+			/^cargo\.toml$/i,
+			/vite\.config\./i,
+			/webpack\.config\./i,
+			/rollup\.config\./i,
+			/jest\.config\./i,
+			/babel\.config\./i,
+			/tailwind\.config\./i,
+			/postcss\.config\./i,
+			/^go\.mod$/i,
+		],
+	},
+	{
+		id: "environment",
+		label: "Environment & CI/CD",
+		patterns: [
+			/^\.env/i,
+			/^dockerfile$/i,
+			/^docker-compose\./i,
+			/^jenkinsfile$/i,
+			/^gemfile$/i,
+			/^requirements\.txt$/i,
+			/^pyproject\.toml$/i,
+			/^setup\.py$/i,
+		],
+	},
+	{
+		id: "editorGit",
+		label: "Editor & Git",
+		patterns: [
+			/^\.gitignore$/i,
+			/^\.gitattributes$/i,
+			/^\.editorconfig$/i,
+			/^\.eslintrc/i,
+			/^\.prettierrc/i,
+		],
+	},
+	{
+		id: "cachesAndBinaries",
+		label: "Caches & Assets",
+		patterns: [
+			/\.tsbuildinfo$/i,
+			/\.properties$/i,
+			/\.pro$/i,
+			/\.(png|jpe?g|gif|svg|webp|ico|zip|tar|gz|rar|7z)$/i,
+		],
+	},
 ];
 
-function isIgnored(filename: string): boolean {
-	return IGNORED_PATTERNS.some((p) => p.test(filename));
+function isIgnored(filename: string, activeFilters: string[]): boolean {
+	for (const category of FILTER_CATEGORIES) {
+		if (activeFilters.includes(category.id)) {
+			if (category.patterns.some((p) => p.test(filename))) {
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 function guessLanguageBucket(filename: string): string {
@@ -92,8 +135,8 @@ function guessLanguageBucket(filename: string): string {
 	return filename;
 }
 
-function filterIgnoredFiles(locs: Locs, name = ""): Locs | null {
-	if (name && isIgnored(name)) return null;
+function filterIgnoredFiles(locs: Locs, activeFilters: string[], name = ""): Locs | null {
+	if (name && isIgnored(name, activeFilters)) return null;
 
 	const newLocs: Locs = {
 		loc: locs.loc,
@@ -104,7 +147,7 @@ function filterIgnoredFiles(locs: Locs, name = ""): Locs | null {
 	if (locs.children) {
 		const newChildren: Record<string, LocsChild> = {};
 		for (const [childName, childValue] of Object.entries(locs.children)) {
-			if (isIgnored(childName)) {
+			if (isIgnored(childName, activeFilters)) {
 				let droppedLoc = typeof childValue === "number" ? childValue : childValue.loc;
 				newLocs.loc -= droppedLoc;
 
@@ -130,7 +173,7 @@ function filterIgnoredFiles(locs: Locs, name = ""): Locs | null {
 				}
 			} else {
 				if (typeof childValue !== "number") {
-					const filteredChild = filterIgnoredFiles(childValue, childName);
+					const filteredChild = filterIgnoredFiles(childValue, activeFilters, childName);
 					if (filteredChild) {
 						newChildren[childName] = filteredChild;
 						const diff = childValue.loc - filteredChild.loc;
@@ -166,7 +209,7 @@ export const ghlocApi = {
 	getLocs: cachedApiFunction("ghlocApi.getLocs", async (params: GhlocApiGetLocsParams) => {
 		const url = getGhlocGetLocsUrl(params);
 		const data = await baseFetcher<GhlocApiGetLocsResponse>(url.toString());
-		const shouldIgnore = params.ignoreConfigs ?? true;
-		return shouldIgnore ? (filterIgnoredFiles(data) || { loc: 0 }) : data;
+		const activeFilters = params.activeFilters ?? [];
+		return activeFilters.length > 0 ? (filterIgnoredFiles(data, activeFilters) || { loc: 0 }) : data;
 	}),
 };

--- a/src/lib/ghloc/api.ts
+++ b/src/lib/ghloc/api.ts
@@ -210,6 +210,6 @@ export const ghlocApi = {
 		const url = getGhlocGetLocsUrl(params);
 		const data = await baseFetcher<GhlocApiGetLocsResponse>(url.toString());
 		const activeFilters = params.activeFilters ?? [];
-		return activeFilters.length > 0 ? (filterIgnoredFiles(data, activeFilters) || { loc: 0 }) : data;
+		return activeFilters.length > 0 ? (filterIgnoredFiles(data, activeFilters) || { loc: 0, children: {} }) : data;
 	}),
 };

--- a/src/lib/ghloc/api.ts
+++ b/src/lib/ghloc/api.ts
@@ -16,6 +16,7 @@ export interface GhlocApiGetLocsParams {
 	repo: string;
 	branch?: string;
 	filter?: string;
+	ignoreConfigs?: boolean;
 }
 
 export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetLocsParams) => {
@@ -34,10 +35,132 @@ export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetL
 	return url;
 };
 
-export const ghlocApi = {
-	getLocs: cachedApiFunction("ghlocApi.getLocs", (params: GhlocApiGetLocsParams) => {
-		const url = getGhlocGetLocsUrl(params);
+const IGNORED_PATTERNS = [
+	/\.json$/i,
+	/lock$/i,
+	/pnpm-lock\.yaml$/i,
+	/gradle$/i,
+	/^gradlew$/i,
+	/^gradlew\.bat$/i,
+	/\.tsbuildinfo$/i,
+	/\.properties$/i,
+	/\.pro$/i,
+	/^makefile$/i,
+	/^pom\.xml$/i,
+	/^build\.xml$/i,
+	/^cargo\.toml$/i,
+	/vite\.config\./i,
+	/webpack\.config\./i,
+	/rollup\.config\./i,
+	/jest\.config\./i,
+	/babel\.config\./i,
+	/tailwind\.config\./i,
+	/postcss\.config\./i,
+	/^go\.mod$/i,
+	/^go\.sum$/i,
+	/^gemfile$/i,
+	/^\.gitignore$/i,
+	/^\.gitattributes$/i,
+	/^\.editorconfig$/i,
+	/^\.env/i,
+	/^dockerfile$/i,
+	/^docker-compose\./i,
+	/^requirements\.txt$/i,
+	/^pyproject\.toml$/i,
+	/^setup\.py$/i,
+	/^\.eslintrc/i,
+	/^\.prettierrc/i,
+	/^jenkinsfile$/i,
+	/\.(png|jpe?g|gif|svg|webp|ico|zip|tar|gz|rar|7z)$/i,
+];
 
-		return baseFetcher<GhlocApiGetLocsResponse>(url.toString());
+function isIgnored(filename: string): boolean {
+	return IGNORED_PATTERNS.some((p) => p.test(filename));
+}
+
+function guessLanguageBucket(filename: string): string {
+	const lastDot = filename.lastIndexOf(".");
+	if (lastDot !== -1 && lastDot !== 0) {
+		return filename.slice(lastDot);
+	}
+	return filename;
+}
+
+function filterIgnoredFiles(locs: Locs, name = ""): Locs | null {
+	if (name && isIgnored(name)) return null;
+
+	const newLocs: Locs = {
+		loc: locs.loc,
+		locByLangs: locs.locByLangs ? { ...locs.locByLangs } : undefined,
+		children: locs.children ? { ...locs.children } : undefined,
+	};
+
+	if (locs.children) {
+		const newChildren: Record<string, LocsChild> = {};
+		for (const [childName, childValue] of Object.entries(locs.children)) {
+			if (isIgnored(childName)) {
+				let droppedLoc = typeof childValue === "number" ? childValue : childValue.loc;
+				newLocs.loc -= droppedLoc;
+
+				if (newLocs.locByLangs) {
+					if (typeof childValue === "number") {
+						const bucket = guessLanguageBucket(childName);
+						if (newLocs.locByLangs[bucket] !== undefined) {
+							newLocs.locByLangs[bucket] -= droppedLoc;
+							if (newLocs.locByLangs[bucket] <= 0) {
+								delete newLocs.locByLangs[bucket];
+							}
+						}
+					} else if (childValue.locByLangs) {
+						for (const [lang, count] of Object.entries(childValue.locByLangs)) {
+							if (newLocs.locByLangs[lang] !== undefined) {
+								newLocs.locByLangs[lang] -= count;
+								if (newLocs.locByLangs[lang] <= 0) {
+									delete newLocs.locByLangs[lang];
+								}
+							}
+						}
+					}
+				}
+			} else {
+				if (typeof childValue !== "number") {
+					const filteredChild = filterIgnoredFiles(childValue, childName);
+					if (filteredChild) {
+						newChildren[childName] = filteredChild;
+						const diff = childValue.loc - filteredChild.loc;
+						if (diff > 0) {
+							newLocs.loc -= diff;
+							if (newLocs.locByLangs && childValue.locByLangs && filteredChild.locByLangs) {
+								for (const lang of Object.keys(childValue.locByLangs)) {
+									const oldL = childValue.locByLangs[lang] || 0;
+									const newL = filteredChild.locByLangs[lang] || 0;
+									const langDiff = oldL - newL;
+									if (langDiff > 0 && newLocs.locByLangs[lang] !== undefined) {
+										newLocs.locByLangs[lang] -= langDiff;
+										if (newLocs.locByLangs[lang] <= 0) {
+											delete newLocs.locByLangs[lang];
+										}
+									}
+								}
+							}
+						}
+					}
+				} else {
+					newChildren[childName] = childValue;
+				}
+			}
+		}
+		newLocs.children = newChildren;
+	}
+
+	return newLocs;
+}
+
+export const ghlocApi = {
+	getLocs: cachedApiFunction("ghlocApi.getLocs", async (params: GhlocApiGetLocsParams) => {
+		const url = getGhlocGetLocsUrl(params);
+		const data = await baseFetcher<GhlocApiGetLocsResponse>(url.toString());
+		const shouldIgnore = params.ignoreConfigs ?? true;
+		return shouldIgnore ? (filterIgnoredFiles(data) || { loc: 0 }) : data;
 	}),
 };

--- a/src/lib/ghloc/api.ts
+++ b/src/lib/ghloc/api.ts
@@ -36,7 +36,13 @@ export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetL
 };
 
 const IGNORED_PATTERNS = [
-	/\.json$/i,
+	/^package\.json$/i,
+	/^tsconfig.*\.json$/i,
+	/^jsconfig.*\.json$/i,
+	/^composer\.json$/i,
+	/^angular\.json$/i,
+	/^nx\.json$/i,
+	/^lerna\.json$/i,
 	/lock$/i,
 	/pnpm-lock\.yaml$/i,
 	/gradle$/i,

--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -128,7 +128,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 
 					<details class="text-sm text-muted group relative">
 						<summary class="cursor-pointer select-none hover:text-foreground transition-colors outline-none list-none flex items-center justify-end gap-1">
-							Filters
+							Exclude
 							<svg class="h-4 w-4 transform transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
 							</svg>

--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -82,57 +82,58 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 
 	return (
 		<div class="flex flex-col gap-2">
-			<div class="flex flex-wrap items-center gap-2">
-				<PathBreadcrums
-					path={[repo, ...path]}
-					onSelect={index => setPath(index === 0 ? [] : path.slice(0, index))}
-				/>
+			<div class="flex flex-wrap items-start gap-2">
+				<div class="flex items-center min-h-[32px] pt-0.5">
+					<PathBreadcrums
+						path={[repo, ...path]}
+						onSelect={index => setPath(index === 0 ? [] : path.slice(0, index))}
+					/>
+				</div>
 
-				<div class="ml-auto flex w-full flex-col items-end gap-2 xs:w-auto">
-					<div class="flex w-full flex-nowrap gap-2">
-						<Select
-							class="w-28"
-							value={sortOrder}
+				<div class="ml-auto flex w-full flex-nowrap items-center gap-2 xs:w-auto">
+					<Select
+						class="w-28"
+						value={sortOrder}
+						onChange={e => {
+							if (e.target instanceof HTMLSelectElement) {
+								setSortOrder(e.target.value as SortOrder);
+							}
+						}}
+						title="Sort order"
+					>
+						<option value="type">Type</option>
+						<option value="locs">Locs</option>
+					</Select>
+
+					<div class="w-full xs:w-48 sm:flex-shrink-0 sm:flex-grow-0">
+						<Input
+							class="w-full"
+							placeholder="Filter"
+							value={filter}
 							onChange={e => {
-								if (e.target instanceof HTMLSelectElement) {
-									setSortOrder(e.target.value as SortOrder);
+								if (e.target instanceof HTMLInputElement) {
+									setFilter(e.target.value);
 								}
 							}}
-							title="Sort order"
-						>
-							<option value="type">Type</option>
-							<option value="locs">Locs</option>
-						</Select>
-
-						<div class="w-full xs:w-48 sm:flex-shrink-0 sm:flex-grow-0">
-							<Input
-								class="w-full"
-								placeholder="Filter"
-								value={filter}
-								onChange={e => {
-									if (e.target instanceof HTMLInputElement) {
-										setFilter(e.target.value);
-									}
-								}}
-								after={
-									(query.status === "fetching" || query.status === "pending") &&
-									locs !== null ? (
-										<SpinnerIcon class="h-5 w-5 animate-spin text-muted" />
-									) : (
-										<FilterHelpTooltip />
-									)
-								}
-							/>
-						</div>
+							after={
+								(query.status === "fetching" || query.status === "pending") &&
+								locs !== null ? (
+									<SpinnerIcon class="h-5 w-5 animate-spin text-muted" />
+								) : (
+									<FilterHelpTooltip />
+								)
+							}
+						/>
 					</div>
-					<details class="text-sm text-muted group mt-1">
+
+					<details class="text-sm text-muted group relative">
 						<summary class="cursor-pointer select-none hover:text-foreground transition-colors outline-none list-none flex items-center justify-end gap-1">
-							Advanced Filters
+							Filters
 							<svg class="h-4 w-4 transform transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
 							</svg>
 						</summary>
-						<div class="mt-2 flex flex-col gap-2 rounded-md border border-border p-3 bg-bg">
+						<div class="absolute right-0 top-[calc(100%+0.5rem)] z-50 flex w-max flex-col gap-2 rounded-md border border-border bg-white p-3 shadow-lg dark:bg-neutral-900">
 							{FILTER_CATEGORIES.map(category => (
 								<label key={category.id} class="flex cursor-pointer items-center gap-2 text-muted hover:text-foreground transition-colors">
 									<input

--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -28,6 +28,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
 	const filter = router.search.get("filter") ?? "";
 	const [debouncedFilter] = useDebouncedValue(filter, 750);
+	const ignoreConfigs = router.search.get("ignoreConfigs") !== "false";
 
 	let path: string[] = [];
 	try {
@@ -42,6 +43,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const { locs, query } = useLocs(path, {
 		sortOrder,
 		filter: debouncedFilter,
+		ignoreConfigs,
 		owner,
 		repo,
 		branch,
@@ -84,41 +86,67 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 					onSelect={index => setPath(index === 0 ? [] : path.slice(0, index))}
 				/>
 
-				<div class="ml-auto flex w-full flex-nowrap gap-2 xs:w-auto">
-					<Select
-						class="w-28"
-						value={sortOrder}
-						onChange={e => {
-							if (e.target instanceof HTMLSelectElement) {
-								setSortOrder(e.target.value as SortOrder);
-							}
-						}}
-						title="Sort order"
-					>
-						<option value="type">Type</option>
-						<option value="locs">Locs</option>
-					</Select>
-
-					<div class="w-full xs:w-48 sm:flex-shrink-0 sm:flex-grow-0">
-						<Input
-							class="w-full"
-							placeholder="Filter"
-							value={filter}
+				<div class="ml-auto flex w-full flex-col items-end gap-2 xs:w-auto">
+					<div class="flex w-full flex-nowrap gap-2">
+						<Select
+							class="w-28"
+							value={sortOrder}
 							onChange={e => {
-								if (e.target instanceof HTMLInputElement) {
-									setFilter(e.target.value);
+								if (e.target instanceof HTMLSelectElement) {
+									setSortOrder(e.target.value as SortOrder);
 								}
 							}}
-							after={
-								(query.status === "fetching" || query.status === "pending") &&
-								locs !== null ? (
-									<SpinnerIcon class="h-5 w-5 animate-spin text-muted" />
-								) : (
-									<FilterHelpTooltip />
-								)
-							}
-						/>
+							title="Sort order"
+						>
+							<option value="type">Type</option>
+							<option value="locs">Locs</option>
+						</Select>
+
+						<div class="w-full xs:w-48 sm:flex-shrink-0 sm:flex-grow-0">
+							<Input
+								class="w-full"
+								placeholder="Filter"
+								value={filter}
+								onChange={e => {
+									if (e.target instanceof HTMLInputElement) {
+										setFilter(e.target.value);
+									}
+								}}
+								after={
+									(query.status === "fetching" || query.status === "pending") &&
+									locs !== null ? (
+										<SpinnerIcon class="h-5 w-5 animate-spin text-muted" />
+									) : (
+										<FilterHelpTooltip />
+									)
+								}
+							/>
+						</div>
 					</div>
+					<label class="flex cursor-pointer items-center gap-1.5 text-sm text-muted hover:text-foreground transition-colors">
+						<input
+							type="checkbox"
+							checked={ignoreConfigs}
+							onChange={e => {
+								if (e.target instanceof HTMLInputElement) {
+									const checked = e.target.checked;
+									router.setSearch(
+										prev => {
+											if (checked) {
+												prev.delete("ignoreConfigs");
+											} else {
+												prev.set("ignoreConfigs", "false");
+											}
+											return prev;
+										},
+										{ replace: true }
+									);
+								}
+							}}
+							class="rounded border-border text-primary focus:ring-primary h-4 w-4"
+						/>
+						Ignore config files
+					</label>
 				</div>
 			</div>
 

--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -15,6 +15,7 @@ import { FileTree } from "./components/FileTree";
 import { FilterHelpTooltip } from "./components/FilterTooltip";
 import { LocsTree } from "./components/LocsTree";
 import { PathBreadcrums } from "./components/PathBreadcrumbs";
+import { FILTER_CATEGORIES } from "~/lib/ghloc/api";
 import { isFolder, SortOrder, useLocs } from "./hooks/useLocs";
 
 interface LocsSectionProps extends CommonSectionProps {
@@ -28,7 +29,8 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
 	const filter = router.search.get("filter") ?? "";
 	const [debouncedFilter] = useDebouncedValue(filter, 750);
-	const ignoreConfigs = router.search.get("ignoreConfigs") !== "false";
+	const activeFiltersRaw = router.search.get("activeFilters");
+	const activeFilters = activeFiltersRaw ? activeFiltersRaw.split(",") : [];
 
 	let path: string[] = [];
 	try {
@@ -43,7 +45,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const { locs, query } = useLocs(path, {
 		sortOrder,
 		filter: debouncedFilter,
-		ignoreConfigs,
+		activeFilters,
 		owner,
 		repo,
 		branch,
@@ -123,30 +125,49 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 							/>
 						</div>
 					</div>
-					<label class="flex cursor-pointer items-center gap-1.5 text-sm text-muted hover:text-foreground transition-colors">
-						<input
-							type="checkbox"
-							checked={ignoreConfigs}
-							onChange={e => {
-								if (e.target instanceof HTMLInputElement) {
-									const checked = e.target.checked;
-									router.setSearch(
-										prev => {
-											if (checked) {
-												prev.delete("ignoreConfigs");
-											} else {
-												prev.set("ignoreConfigs", "false");
+					<details class="text-sm text-muted group mt-1">
+						<summary class="cursor-pointer select-none hover:text-foreground transition-colors outline-none list-none flex items-center justify-end gap-1">
+							Advanced Filters
+							<svg class="h-4 w-4 transform transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+							</svg>
+						</summary>
+						<div class="mt-2 flex flex-col gap-2 rounded-md border border-border p-3 bg-bg">
+							{FILTER_CATEGORIES.map(category => (
+								<label key={category.id} class="flex cursor-pointer items-center gap-2 text-muted hover:text-foreground transition-colors">
+									<input
+										type="checkbox"
+										checked={activeFilters.includes(category.id)}
+										onChange={e => {
+											if (e.target instanceof HTMLInputElement) {
+												const checked = e.target.checked;
+												router.setSearch(
+													prev => {
+														let filters = prev.get("activeFilters") ? prev.get("activeFilters")!.split(",") : [];
+														if (checked) {
+															if (!filters.includes(category.id)) filters.push(category.id);
+														} else {
+															filters = filters.filter(f => f !== category.id);
+														}
+
+														if (filters.length > 0) {
+															prev.set("activeFilters", filters.join(","));
+														} else {
+															prev.delete("activeFilters");
+														}
+														return prev;
+													},
+													{ replace: true }
+												);
 											}
-											return prev;
-										},
-										{ replace: true }
-									);
-								}
-							}}
-							class="rounded border-border text-primary focus:ring-primary h-4 w-4"
-						/>
-						Ignore config files
-					</label>
+										}}
+										class="rounded border-border text-primary focus:ring-primary h-4 w-4"
+									/>
+									<span class="flex-1">Ignore {category.label}</span>
+								</label>
+							))}
+						</div>
+					</details>
 				</div>
 			</div>
 

--- a/src/pages/repo/components/LocsSection/hooks/useLocs.tsx
+++ b/src/pages/repo/components/LocsSection/hooks/useLocs.tsx
@@ -14,7 +14,7 @@ export interface UseLocsOptions {
 	owner: string;
 	repo: string;
 	branch?: string;
-	ignoreConfigs?: boolean;
+	activeFilters?: string[];
 }
 
 export function isFolder(child: LocsChild): child is Locs {
@@ -23,11 +23,11 @@ export function isFolder(child: LocsChild): child is Locs {
 
 export function useLocs(
 	path: string[],
-	{ sortOrder, filter, owner, repo, branch, ignoreConfigs }: UseLocsOptions,
+	{ sortOrder, filter, owner, repo, branch, activeFilters }: UseLocsOptions,
 ) {
 	const query = useQuery({
-		queryKey: ["locs", owner, repo, branch, filter, String(ignoreConfigs)],
-		queryFn: () => ghlocApi.getLocs({ owner, repo, branch, filter, ignoreConfigs }),
+		queryKey: ["locs", owner, repo, branch, filter, JSON.stringify(activeFilters)],
+		queryFn: () => ghlocApi.getLocs({ owner, repo, branch, filter, activeFilters }),
 	});
 
 	useEffect(() => {

--- a/src/pages/repo/components/LocsSection/hooks/useLocs.tsx
+++ b/src/pages/repo/components/LocsSection/hooks/useLocs.tsx
@@ -14,6 +14,7 @@ export interface UseLocsOptions {
 	owner: string;
 	repo: string;
 	branch?: string;
+	ignoreConfigs?: boolean;
 }
 
 export function isFolder(child: LocsChild): child is Locs {
@@ -22,11 +23,11 @@ export function isFolder(child: LocsChild): child is Locs {
 
 export function useLocs(
 	path: string[],
-	{ sortOrder, filter, owner, repo, branch }: UseLocsOptions,
+	{ sortOrder, filter, owner, repo, branch, ignoreConfigs }: UseLocsOptions,
 ) {
 	const query = useQuery({
-		queryKey: ["locs", owner, repo, branch, filter],
-		queryFn: () => ghlocApi.getLocs({ owner, repo, branch, filter }),
+		queryKey: ["locs", owner, repo, branch, filter, String(ignoreConfigs)],
+		queryFn: () => ghlocApi.getLocs({ owner, repo, branch, filter, ignoreConfigs }),
 	});
 
 	useEffect(() => {
@@ -78,25 +79,31 @@ export function useLocs(
 			return pathLocs;
 		}
 
-		if (sortOrder === "locs") {
-			return pathLocs;
-		}
-
 		const names = Object.keys(children);
 
-		names.sort((nameA, nameB) => {
-			const a = children[nameA] as Locs;
-			const b = children[nameB] as Locs;
+		if (sortOrder === "locs") {
+			names.sort((nameA, nameB) => {
+				const a = children[nameA];
+				const b = children[nameB];
+				const locA = typeof a === "number" ? a : a.loc;
+				const locB = typeof b === "number" ? b : b.loc;
+				return locB - locA;
+			});
+		} else {
+			names.sort((nameA, nameB) => {
+				const a = children[nameA] as Locs;
+				const b = children[nameB] as Locs;
 
-			const isFolderA = isFolder(a);
-			const isFolderB = isFolder(b);
+				const isFolderA = isFolder(a);
+				const isFolderB = isFolder(b);
 
-			if (isFolderA !== isFolderB) {
-				return Number(isFolderB) - Number(isFolderA);
-			}
+				if (isFolderA !== isFolderB) {
+					return Number(isFolderB) - Number(isFolderA);
+				}
 
-			return nameA < nameB ? -1 : 1;
-		});
+				return nameA < nameB ? -1 : 1;
+			});
+		}
 
 		const sortedChildren: Record<string, LocsChild> = {};
 		for (const name of names) {

--- a/src/routes/api/[owner]/[repo]/badge.get.ts
+++ b/src/routes/api/[owner]/[repo]/badge.get.ts
@@ -5,11 +5,11 @@ import { ghApi } from "~/lib/github/api";
 
 export default defineEventHandler(async event => {
 	const { owner, repo } = getRouterParams(event);
-	let { branch, filter, format, ignoreConfigs } = getQuery<{
+	let { branch, filter, format, activeFilters } = getQuery<{
 		branch?: string;
 		filter?: string;
 		format?: string;
-		ignoreConfigs?: string;
+		activeFilters?: string;
 	}>(event);
 
 	const { timing } = event.context;
@@ -27,7 +27,7 @@ export default defineEventHandler(async event => {
 				repo, 
 				branch, 
 				filter, 
-				ignoreConfigs: ignoreConfigs !== "false" 
+				activeFilters: activeFilters ? activeFilters.split(",") : []
 			}),
 		);
 	} catch (e) {

--- a/src/routes/api/[owner]/[repo]/badge.get.ts
+++ b/src/routes/api/[owner]/[repo]/badge.get.ts
@@ -5,10 +5,11 @@ import { ghApi } from "~/lib/github/api";
 
 export default defineEventHandler(async event => {
 	const { owner, repo } = getRouterParams(event);
-	let { branch, filter, format } = getQuery<{
+	let { branch, filter, format, ignoreConfigs } = getQuery<{
 		branch?: string;
 		filter?: string;
 		format?: string;
+		ignoreConfigs?: string;
 	}>(event);
 
 	const { timing } = event.context;
@@ -21,7 +22,13 @@ export default defineEventHandler(async event => {
 		}
 
 		locs = await timing.timeAsync("locs", () =>
-			ghlocApi.getLocs({ owner, repo, branch, filter }),
+			ghlocApi.getLocs({ 
+				owner, 
+				repo, 
+				branch, 
+				filter, 
+				ignoreConfigs: ignoreConfigs !== "false" 
+			}),
 		);
 	} catch (e) {
 		console.error("Failed to fetch locs", e);

--- a/src/routes/api/[owner]/[repo]/og-image.get.tsx
+++ b/src/routes/api/[owner]/[repo]/og-image.get.tsx
@@ -14,10 +14,11 @@ const colors = {
 
 export default defineEventHandler(async event => {
 	const { owner, repo } = getRouterParams(event);
-	let { branch, filter } = getQuery<{
+	let { branch, filter, format, ignoreConfigs } = getQuery<{
 		branch?: string;
 		filter?: string;
 		format?: string;
+		ignoreConfigs?: string;
 	}>(event);
 
 	const { timing } = event.context;
@@ -30,7 +31,13 @@ export default defineEventHandler(async event => {
 		}
 
 		locs = await timing.timeAsync("locs", () =>
-			ghlocApi.getLocs({ owner, repo, branch, filter }),
+			ghlocApi.getLocs({ 
+				owner, 
+				repo, 
+				branch, 
+				filter, 
+				ignoreConfigs: ignoreConfigs !== "false" 
+			}),
 		);
 	} catch (e) {
 		console.error("Failed to fetch locs", e);

--- a/src/routes/api/[owner]/[repo]/og-image.get.tsx
+++ b/src/routes/api/[owner]/[repo]/og-image.get.tsx
@@ -14,11 +14,11 @@ const colors = {
 
 export default defineEventHandler(async event => {
 	const { owner, repo } = getRouterParams(event);
-	let { branch, filter, format, ignoreConfigs } = getQuery<{
+	let { branch, filter, format, activeFilters } = getQuery<{
 		branch?: string;
 		filter?: string;
 		format?: string;
-		ignoreConfigs?: string;
+		activeFilters?: string;
 	}>(event);
 
 	const { timing } = event.context;
@@ -36,7 +36,7 @@ export default defineEventHandler(async event => {
 				repo, 
 				branch, 
 				filter, 
-				ignoreConfigs: ignoreConfigs !== "false" 
+				activeFilters: activeFilters ? activeFilters.split(",") : []
 			}),
 		);
 	} catch (e) {


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows users to exclude specific file categories (like Lockfiles, Configs, Build Scripts, etc.) from the overall Lines of Code (LOC) calculation. This provides a much more accurate representation of the actual source code written by developers

### Key Changes:
- **"Exclude" Menu:** Added a new dropdown menu next to the search input, allowing users to quickly toggle predefined exclusion filters
- **URL Synchronization:** Active filters are synced to the URL (`?activeFilters=...`) so that the exact state can be easily shared
- **Badge & OG Image Support:** The `activeFilters` parameter is fully supported by the badge (`/badge`) and Open Graph image (`/og-image`) API endpoints, meaning users can now generate shields.io badges that exclude lockfiles/configs using `?activeFilters=jsonConfigs,lockfiles`
- **Backend handling:** Instead of modifying the core backend, the filtering math is done in the Node.js API wrapper (`src/lib/ghloc/api.ts`). It traverses the returned JSON, strips out the ignored files, and automatically recalculates the total `loc` and `locByLangs` dictionary before passing it to the frontend
- **Docs:** Updated `README.md` with an example of how to use this parameter for badges

### Filter Categories Added:
- `jsonConfigs` (e.g. package.json, tsconfig.json)
- `lockfiles` (e.g. pnpm-lock.yaml, go.sum)
- `buildScripts` (e.g. Makefile, webpack.config.js)
- `environment` (e.g. Dockerfile, .env)
- `editorGit` (e.g. .gitignore, .prettierrc)
- `cachesAndBinaries` (e.g. .png, .zip)

## How I tested this:
- Tested the filtering in the UI (checking different combinations and verifying that the LOC count and file tree update correctly)
- Created a local HTTPS tunnel (via localhost.run/ngrok) to expose the local API endpoint to the internet and successfully rendered the actual SVGs on the live `shields.io` server
- Passed multiple query combinations to the badge URL to ensure the API safely handles parsing and ignores invalid values

## exclude option

<img width="889" height="227" alt="Captura_de_tela_20260620_194752" src="https://github.com/user-attachments/assets/2c311dfa-4646-4a08-ad98-9e53d9063181" />

## exclude menu

<img width="889" height="269" alt="Captura_de_tela_20260620_194800" src="https://github.com/user-attachments/assets/0b116ca1-4d6d-4006-9bbe-5ad4141bce2b" />

##  total lines (without exclude options)

<img width="889" height="269" alt="Captura_de_tela_20260620_194821" src="https://github.com/user-attachments/assets/c332a72e-0369-462b-b16d-7bac71814bd9" />

## with only three first exclude options

<img width="889" height="269" alt="Captura_de_tela_20260620_194830" src="https://github.com/user-attachments/assets/a3a0bbb7-53a6-449a-b96b-2c422ee1d79b" />

### but is the badge (buildScripts, Clockfiles, jsonConfigs)

<img width="423" height="106" alt="Captura_de_tela_20260620_201257" src="https://github.com/user-attachments/assets/b621705b-8507-4470-b06f-7b5da445527f" />

## with only three last exclude options

<img width="889" height="269" alt="Captura_de_tela_20260620_194837" src="https://github.com/user-attachments/assets/081872c0-5735-4d86-a93b-3250db6b5cf5" />

### but is the badge (cachesAndBinaries, editorGit, environment)

<img width="423" height="106" alt="Captura_de_tela_20260620_201549" src="https://github.com/user-attachments/assets/0151b5a2-4637-4616-8b30-7ddd344c17fe" />

## with all exclude options

<img width="793" height="223" alt="Captura_de_tela_20260620_194844" src="https://github.com/user-attachments/assets/f5712b70-ea0d-41c1-8d1d-47fd1006bbec" />

### but is the badge (buildScripts, Clockfiles, jsonConfigs, cachesAndBinaries, editorGit, environment)

<img width="423" height="106" alt="Captura_de_tela_20260620_202004" src="https://github.com/user-attachments/assets/aa12b93a-30b8-4c4c-87c0-ff0c0ae26d6f" />
