### PR TITLE
fix(locs): guard against non-array locsPath param

### DIFF
--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -21,6 +21,24 @@ interface LocsSectionProps extends CommonSectionProps {
 	branch: string;
 }
 
+function parseLocsPath(value: string | null): string[] {
+	if (!value) {
+		return [];
+	}
+
+	try {
+		const parsed: unknown = JSON.parse(value);
+
+		if (Array.isArray(parsed) && parsed.every(segment => typeof segment === "string")) {
+			return parsed;
+		}
+	} catch {
+		/* ignore malformed locsPath */
+	}
+
+	return [];
+}
+
 export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const router = useRouter();
 
@@ -29,15 +47,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 	const filter = router.search.get("filter") ?? "";
 	const [debouncedFilter] = useDebouncedValue(filter, 750);
 
-	let path: string[] = [];
-	try {
-		const locsPath = router.search.get("locsPath");
-		if (locsPath) {
-			path = JSON.parse(locsPath);
-		}
-	} catch {
-		/* empty */
-	}
+	const path = parseLocsPath(router.search.get("locsPath"));
 
 	const { locs, query } = useLocs(path, {
 		sortOrder,


### PR DESCRIPTION
A malformed `locsPath` query param can crash the LOC section with an unhandled render exception.

`LocsSection` parses `locsPath` like this:

```ts
let path: string[] = [];
try {
  const locsPath = router.search.get("locsPath");
  if (locsPath) path = JSON.parse(locsPath);
} catch {
  /* empty */
}
```

The `try/catch` only guards against _invalid_ JSON. Valid JSON that isn't a `string[]` slips through and `path` ends up non-iterable, so `[repo, ...path]` (breadcrumbs) and `for (const dir of path)` (in `useLocs`) throw `TypeError: path is not iterable`.

### Repro

Open any repo page and append one of these params:

| URL param           | Before                     | After     |
| ------------------- | -------------------------- | --------- |
| `?locsPath=42`      | 💥 crash                   | root view |
| `?locsPath=null`    | 💥 crash                   | root view |
| `?locsPath={}`      | 💥 crash                   | root view |
| `?locsPath="hi"`    | breadcrumbs become `h / i` | root view |
| `?locsPath=["src"]` | works                      | works     |

Since `locsPath` is shareable in the URL, a hand-edited or stale link is enough to trigger it.

### Fix

Extract a `parseLocsPath` helper that returns the value only when it's an array of strings, and falls back to `[]` otherwise. No behavior change for well-formed paths.

### Testing

- Verified the helper returns `[]` for `42`, `null`, `true`, `{}`, `{"a":1}`, `"hello"`, `[1,2]`, `foo`, `null`, and `""`, and passes `["src","lib"]` through unchanged.
- Manually confirmed the page renders the repo root instead of crashing for each bad param above.