### PR TITLE
feat: add branch selector with SSR pre-fetching

### DIFF
--- a/src/lib/github/api.ts
+++ b/src/lib/github/api.ts
@@ -56,6 +56,9 @@ export type GHApiSearchReposResponse = Endpoints["GET /search/repositories"]["re
 
 export type GHApiGetReposResponse = Endpoints["GET /users/{username}/repos"]["response"]["data"];
 
+export type GHApiGetBranchesResponse =
+	Endpoints["GET /repos/{owner}/{repo}/branches"]["response"]["data"];
+
 type GHApiRepoHealthFile = NonNullable<
 	NonNullable<GHApiGetRepoHealthResponse["files"]>["issue_template"]
 >;
@@ -207,5 +210,14 @@ export const ghApi = {
 		return fetcher<GHApiGetReposResponse>(`https://api.github.com/users/${owner}/repos`, {
 			params: { per_page: limit, sort: "updated" },
 		});
+	}),
+
+	getBranches: cachedApiFunction("ghApi.getBranches", async (owner: string, repo: string) => {
+		return fetcher<GHApiGetBranchesResponse>(
+			`https://api.github.com/repos/${owner}/${repo}/branches`,
+			{
+				params: { per_page: 100 },
+			},
+		);
 	}),
 };

--- a/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
+++ b/src/pages/repo/components/LocsSection/LocsSection.island.lazy.tsx
@@ -1,4 +1,4 @@
-import { useState } from "hono/jsx";
+import { useMemo, useState } from "hono/jsx";
 import { Heading } from "~/components/Heading";
 import { SpinnerIcon } from "~/components/icons/SpinnerIcon";
 import { Input } from "~/components/Input";
@@ -19,6 +19,7 @@ import { isFolder, SortOrder, useLocs } from "./hooks/useLocs";
 
 interface LocsSectionProps extends CommonSectionProps {
 	branch: string;
+	branches?: string[];
 }
 
 function parseLocsPath(value: string | null): string[] {
@@ -39,13 +40,25 @@ function parseLocsPath(value: string | null): string[] {
 	return [];
 }
 
-export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
+export default function LocsSection({ owner, repo, branch, branches = [] }: LocsSectionProps) {
 	const router = useRouter();
 
+	const branchName = router.search.get("branch") ?? branch;
 	const [sortOrder, setSortOrder] = useState<SortOrder>("type");
 	const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
 	const filter = router.search.get("filter") ?? "";
 	const [debouncedFilter] = useDebouncedValue(filter, 750);
+
+	const availableBranches = useMemo(() => {
+		const set = new Set<string>();
+		if (branch) set.add(branch);
+		if (branchName) set.add(branchName);
+		for (const b of branches) {
+			set.add(b);
+		}
+
+		return Array.from(set);
+	}, [branch, branchName, branches]);
 
 	const path = parseLocsPath(router.search.get("locsPath"));
 
@@ -54,7 +67,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 		filter: debouncedFilter,
 		owner,
 		repo,
-		branch,
+		branch: branchName,
 	});
 
 	const setPath = (newPath: string[]) => {
@@ -84,6 +97,22 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 		);
 	};
 
+	const setBranchName = (newBranch: string) => {
+		router.setSearch(
+			prev => {
+				if (newBranch) {
+					prev.set("branch", newBranch);
+				} else {
+					prev.delete("branch");
+				}
+				prev.delete("locsPath");
+
+				return prev;
+			},
+			{ replace: false },
+		);
+	};
+
 	const isFile = locs !== null && !isFolder(locs);
 
 	return (
@@ -95,6 +124,21 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 				/>
 
 				<div class="ml-auto flex w-full flex-nowrap gap-2 xs:w-auto">
+					<Select
+						class="w-32"
+						value={branchName}
+						onChange={e => {
+							if (e.target instanceof HTMLSelectElement) {
+								setBranchName(e.target.value);
+							}
+						}}
+						title="Branch"
+					>
+						{availableBranches.map(b => (
+							<option value={b}>{b}</option>
+						))}
+					</Select>
+
 					<Select
 						class="w-28"
 						value={sortOrder}
@@ -146,7 +190,7 @@ export default function LocsSection({ owner, repo, branch }: LocsSectionProps) {
 								<FilePreview
 									owner={owner}
 									repo={repo}
-									branch={branch}
+									branch={branchName}
 									path={path}
 									loc={locs}
 								/>

--- a/src/pages/repo/index.tsx
+++ b/src/pages/repo/index.tsx
@@ -8,6 +8,7 @@ import { CommonSectionProps } from "./types";
 
 interface RepoPageProps extends CommonSectionProps {
 	branch: string;
+	branches?: string[];
 }
 
 export const RepoPage = (props: RepoPageProps) => {

--- a/src/routes/[owner]/[repo].get.tsx
+++ b/src/routes/[owner]/[repo].get.tsx
@@ -30,17 +30,28 @@ export default defineEventHandler(async event => {
 
 	setHeader(event, "cache-control", "public, max-age=60");
 
-	return renderPage(<RepoPage owner={owner} repo={repo} branch={branch} data={data} />, {
-		event,
-		title: `${owner}/${repo}`,
-		ogImage: `api/${owner}/${repo}/og-image?branch=${encodeURIComponent(branch)}`,
-		preload: [
-			{
-				href: getGhlocGetLocsUrl({ owner, repo, branch, filter }).toString(),
-				as: "fetch",
-				crossorigin: "anonymous",
-			},
-		],
-		preloadIslands: [LocsSection],
-	});
+	const branches = await timing
+		.timeAsync("branches", () => ghApi.getBranches(owner, repo))
+		.then(res => res.map(b => b.name))
+		.catch(error => {
+			console.error("Failed to fetch branches:", error);
+			return [] as string[];
+		});
+
+	return renderPage(
+		<RepoPage owner={owner} repo={repo} branch={branch} branches={branches} data={data} />,
+		{
+			event,
+			title: `${owner}/${repo}`,
+			ogImage: `api/${owner}/${repo}/og-image?branch=${encodeURIComponent(branch)}`,
+			preload: [
+				{
+					href: getGhlocGetLocsUrl({ owner, repo, branch, filter }).toString(),
+					as: "fetch",
+					crossorigin: "anonymous",
+				},
+			],
+			preloadIslands: [LocsSection],
+		},
+	);
 });


### PR DESCRIPTION
## Summary
Adds a branch selector dropdown to the repository lines-of-code (`LocsSection`) section, allowing users to view and switch between all available repository branches seamlessly.

## Key Changes
- **GitHub API Integration**: Added `getBranches` endpoint method (`GET /repos/{owner}/{repo}/branches`) to `ghApi` in `src/lib/github/api.ts`.
- **SSR Pre-fetching**: Updated the server route handler in `src/routes/[owner]/[repo].get.tsx` to pre-fetch repository branches on the server and pass them down as props to `<RepoPage>`. This ensures the dropdown is fully populated on initial HTML render without client-side network waterfalls or rate-limit issues.
- **Dynamic Branch Syncing**: Configured `LocsSection.island.lazy.tsx` to sync branch selection with URL search parameters (`?branch=...`), automatically resetting folder navigation (`locsPath`) and refetching LOC stats for the selected branch.

## Testing
- Verified TypeScript compilation and prop types with `pnpm lint:tsc`.
