### PR TITLE
fix: support forward slash in branch names

### DIFF
--- a/src/lib/ghloc/api.ts
+++ b/src/lib/ghloc/api.ts
@@ -22,7 +22,7 @@ export const getGhlocGetLocsUrl = ({ owner, repo, branch, filter }: GhlocApiGetL
 	const url = new URL(`https://ghloc.ifels.dev/${owner}/${repo}`);
 
 	if (branch) {
-		url.pathname += `/${branch}`;
+		url.pathname += `/${encodeURIComponent(branch)}`;
 	}
 
 	if (filter) {


### PR DESCRIPTION
Browsing to 
https://ghloc.dev/rickernet/SlayerPlus?branch=codex%2Freview-size-refactor

Calls `https://ghloc.ifels.dev/rickernet/SlayerPlus/codex/Freview-size-refactor?pretty=false`

```
curl -i 'https://ghloc.ifels.dev/rickernet/SlayerPlus/codex/Freview-size-refactor?pretty=false' 
HTTP/2 404 
date: Sun, 23 Aug 2026 03:25:13 GMT
content-type: text/plain; charset=utf-8
content-length: 19
vary: Origin
x-content-type-options: nosniff
strict-transport-security: max-age=15724800; includeSubDomains

404 page not found
```

After the fix:
```
curl -i 'https://ghloc.ifels.dev/rickernet/SlayerPlus/codex%2Freview-size-refactor?pretty=false'
HTTP/2 200 
date: Sun, 23 Aug 2026 03:14:04 GMT
content-type: application/json
cache-control: public, max-age=300
vary: Origin
strict-transport-security: max-age=15724800; includeSubDomains

{"loc":51301,"locByLangs":{".java":46852,".tsv":3760,"gradlew":224,".md":153,".gradle":108,".bat":73,".xml":48,".gitignore":45,"LICENSE":20,".properties":14,".png":3,".jar":1},"children":{"src":{"loc":36712,"locByLangs":{".java":32902,".tsv":3760,".xml":48,".png":2},"children":{"main":{"loc":36297,"locByLangs":{".java":32890,".tsv":3405,".png":2},"children":{"java":{"loc":32890,"locByLangs":{".java":32890},"children":{"com":{"loc":32890,"locByLangs":{".java":32890},"children":{"slayerplus":{"loc":32890,"locByLangs":{".java":32890},"children":{"SlayerPlusPlugin.java":8287,"SlayerLoadoutAnalyzer.java":5017,"SlayerPlusPanel.java":1790,"PlayerPortraitRenderer.java":1433,"BankTagLayout.java":1278,"RouteCatalog.java":1244,"TeleportHighlighter.java":1092,"PreparationCatalog.java":1018,"ShortestPathBridge.java":908,"SlayerRecommendationEngine.java":763,"MethodRules.java":739,"RoutePlan.java":652,"PlayerPortraitPanel.java":593,"RouteCheck.java":532,"TaskStrategy.java":503,"SlayerMethodRuleCatalog.java":484,"VariantCatalog.java":476,"SlayerTaskStrategyCatalog.java":402,"QuiverAmmo.java":365,"SlayerRoutePlanResource.java":354,"SlayerTeleportRouteRegistry.java":333,"SlayerEquipmentAuditCatalog.java":294,"SlayerAchievementDiarySnapshot.java":268,"SlayerBossInventoryCatalog.java":257,"SlayerRegularInventoryAuditCatalog.java":236,"TravelRoutes.java":210,"RouteEvidence.java":207,"TravelChoice.java":193,"SlayerTravelCoordinator.java":190,"SlayerTaskNpcCatalog.java":182,"RunePolicy.java":164,"KitPlan.java":161,"SlayerTaskReadinessOverlay.java":152,"SlayerElementalWeaknessCatalog.java":128,"SlayerPlusConfig.java":127,"Preference.java":116,"Recommendation.java":115,"GuideLifecycle.java":108,"SlayerRouteCoordinator.java":97,"KitItem.java":95,"SlayerDisplayText.java":93,"MasterRoutes.java":89,"SlayerBraceletChargeTracker.java":85,"SlayerSpellbookRouteCatalog.java":83,"SlayerBraceletChargeInfoBox.java":80,"PotionPolicy.java":78,"TaskResearch.java":77,"SlayerRoutePlanCatalog.java":75,"SlayerEncounterStandards.java":74,"TuraelBoost.java":71,"SlayerTaskChatUpdate.java":70,"BankRoutes.java":59,"ResourceTable.java":59,"SlayerTargetFootprintCatalog.java":58,"SlayerTaskTravelAuditCatalog.java":51,"SlayerTravelItemPolicy.java":48,"BoostCoordinator.java":47,"TaskVariant.java":45,"SlayerTravelItemOverlay.java":43,"HelmetPreference.java":22,"SlayerText.java":15,"SlayerBankOverlay.java":5}}}}}},"resources":{"loc":3407,"locByLangs":{".tsv":3405,".png":2},"children":{"com":{"loc":3407,"locByLangs":{".tsv":3405,".png":2},"children":{"slayerplus":{"loc":3407,"locByLangs":{".tsv":3405,".png":2},"children":{"slayer-route-plans.tsv":624,"slayer-task-strategies.tsv":580,"slayer-travel-routes.tsv":353,"slayer-route-profiles.tsv":332,"slayer-task-npcs.tsv":200,"slayer-task-travel-audit.tsv":174,"slayer-bank-targets.tsv":168,"slayer-task-research.tsv":166,"slayer-equipment-lists.tsv":159,"slayer-regular-inventory.tsv":117,"slayer-boss-inventory.tsv":110,"slayer-task-aliases.tsv":80,"slayer-task-locations.tsv":64,"slayer-elemental-weaknesses.tsv":57,"slayer-task-variants.tsv":53,"slayer-loadout-lists.tsv":50,"slayer-boss-method-guidance.tsv":44,"slayer-loadout-arrays.tsv":26,"slayer-equipment-profiles.tsv":24,"slayer-turael-boost.tsv":24,"slayerplus_icon.png":1,"slayerplus_sidebar_v2.png":1}}}}}}}},"test":{"loc":415,"locByLangs":{".tsv":355,".xml":48,".java":12},"children":{"resources":{"loc":403,"locByLangs":{".tsv":355,".xml":48},"children":{"com":{"loc":355,"locByLangs":{".tsv":355},"children":{"slayerplus":{"loc":355,"locByLangs":{".tsv":355},"children":{"slayer-route-release-manifest.tsv":355}}}},"logback-test.xml":48}},"java":{"loc":12,"locByLangs":{".java":12},"children":{"com":{"loc":12,"locByLangs":{".java":12},"children":{"slayerplus":{"loc":12,"locByLangs":{".java":12},"children":{"SlayerPlusPluginTest.java":12}}}}}}}}}},"verification":{"loc":13950,"locByLangs":{".java":13950},"children":{"java":{"loc":13950,"locByLangs":{".java":13950},"children":{"com":{"loc":13950,"locByLangs":{".java":13950},"children":{"slayerplus":{"loc":13950,"locByLangs":{".java":13950},"children":{"SlayerRegressionTest.java":5686,"SlayerRouteReleaseValidator.java":2268,"SlayerRouteReleaseValidatorTest.java":973,"SlayerRoutePlanCatalogTest.java":928,"SlayerTaskStrategyValidator.java":763,"SlayerCatalogRegressionValidator.java":616,"SlayerArchitectureRegressionGuard.java":503,"SlayerQuiverRegressionTest.java":479,"ShortestPathResponseCorrelationTest.java":474,"SlayerRoutePlanTest.java":459,"SlayerRouteReleaseManifest.java":192,"SlayerRouteLifecycleRegressionTest.java":156,"SlayerGuidedLifecycleContractTest.java":135,"SlayerMethodRuleCoverage.java":87,"ShortestPathTaskTransportLifecycleTest.java":63,"SlayerBraceletChargeTrackerTest.java":62,"SlayerRoutePlanRuntimeRegressionTest.java":62,"SlayerDiscordButtonRegressionTest.java":44}}}}}}}},"gradlew":224,"AGENTS.md":117,"build.gradle":107,"gradlew.bat":73,".gitignore":45,"README.md":35,"LICENSE":20,"gradle":{"loc":9,"locByLangs":{".properties":8,".jar":1},"children":{"wrapper":{"loc":9,"locByLangs":{".properties":8,".jar":1},"children":{"gradle-wrapper.properties":8,"gradle-wrapper.jar":1}}}},"runelite-plugin.properties":6,"CLAUDE.md":1,"icon.png":1,"settings.gradle":1}}
```